### PR TITLE
fix: remove tracking for Manual Donations

### DIFF
--- a/includes/actions.php
+++ b/includes/actions.php
@@ -23,7 +23,7 @@ function give_google_analytics_send_donation_success( $donation_id, $new_status,
 	}
 
 	// Check conditions.
-	$sent_already = get_post_meta( $donation_id, '_give_ga_beacon_sent', true );
+	$sent_already = give_get_meta( $donation_id, '_give_ga_beacon_sent', true );
 
 	if ( ! empty( $sent_already ) ) {
 		return false;
@@ -88,7 +88,7 @@ function give_google_analytics_send_donation_success( $donation_id, $new_status,
 		}
 
 		/**
-		 * Filter the google analatic query params
+		 * Filter the google analytics query params.
 		 *
 		 * @since 1.0.0
 		 */
@@ -101,7 +101,7 @@ function give_google_analytics_send_donation_success( $donation_id, $new_status,
 		// Check if beacon sent successfully.
 		if ( ! is_wp_error( $request ) || 200 == wp_remote_retrieve_response_code( $request ) ) {
 
-			add_post_meta( $donation_id, '_give_ga_beacon_sent', true );
+			give_update_payment_meta( $donation_id, '_give_ga_beacon_sent', true );
 			give_insert_payment_note( $donation_id, __( 'Google Analytics ecommerce tracking beacon sent.', 'give-google-analytics' ) );
 		}
 	}// End if().
@@ -112,9 +112,9 @@ add_action( 'give_update_payment_status', 'give_google_analytics_send_donation_s
 
 
 /**
- * Save google analytic session data
+ * Save Google Analytic session data
  *
- * @since 2.0.0
+ * @since 1.2.2
  *
  * @param int $payment_id Donation ID.
  */
@@ -127,15 +127,15 @@ function give_ga_preserve_google_session_data( $payment_id ) {
 		$client_id = explode( '.', $_COOKIE['_ga'], 3 );
 		$client_id = array_pop( $client_id );
 
-		add_post_meta( $payment_id, '_give_ga_client_id', $client_id );
+		give_update_payment_meta( $payment_id, '_give_ga_client_id', $client_id );
 
 		$campaign        = empty( $_COOKIE['give_campaign'] ) ? '' : $_COOKIE['give_campaign'];
 		$campaign_source = empty( $_COOKIE['give_source'] ) ? '' : $_COOKIE['give_source'];
 		$campaign_medium = empty( $_COOKIE['give_medium'] ) ? '' : $_COOKIE['give_medium'];
 
-		add_post_meta( $payment_id, '_give_ga_campaign', $campaign );
-		add_post_meta( $payment_id, '_give_ga_campaign_source', $campaign_source );
-		add_post_meta( $payment_id, '_give_ga_campaign_medium', $campaign_medium );
+		give_update_payment_meta( $payment_id, '_give_ga_campaign', $campaign );
+		give_update_payment_meta( $payment_id, '_give_ga_campaign_source', $campaign_source );
+		give_update_payment_meta( $payment_id, '_give_ga_campaign_medium', $campaign_medium );
 	}
 }
 add_action( 'give_insert_payment', 'give_ga_preserve_google_session_data' );
@@ -158,7 +158,7 @@ function give_google_analytics_send_refund_beacon( $donation_id, $new_status, $o
 	// Bailout.
 	if ( 'refunded' === $new_status || 'publish' === $old_status ) {
 		// Check if the beacon has already been sent.
-		$beacon_sent = get_post_meta( $donation_id, '_give_ga_refund_beacon_sent', true );
+		$beacon_sent = give_get_meta( $donation_id, '_give_ga_refund_beacon_sent', true );
 
 		if ( ! empty( $beacon_sent ) ) {
 			return false;
@@ -186,7 +186,7 @@ function give_google_analytics_send_refund_beacon( $donation_id, $new_status, $o
 		// Check if beacon sent successfully.
 		if ( ! is_wp_error( $request ) || 200 == wp_remote_retrieve_response_code( $request ) ) {
 
-			add_post_meta( $donation_id, '_give_ga_refund_beacon_sent', true );
+			give_update_payment_meta( $donation_id, '_give_ga_refund_beacon_sent', true );
 
 			// All is well, sent beacon.
 			give_insert_payment_note( $donation_id, __( 'Google Analytics donation refund tracking beacon sent.', 'give-google-analytics' ) );

--- a/includes/actions.php
+++ b/includes/actions.php
@@ -155,14 +155,22 @@ function give_google_analytics_send_refund_beacon( $donation_id, $new_status, $o
 		return false;
 	}
 
+	// Check if the DONATION beacon has been sent (successful "purchase").
+	// If it hasn't then return false; only send refunds for donations tracked in GA.
+	$donation_beacon_sent = give_get_meta( $donation_id, '_give_ga_beacon_sent', true );
+	if ( empty( $donation_beacon_sent ) ) {
+		return false;
+	}
+
+	// Check if the REFUND beacon has already been sent.
+	// If it hasn't proceed.
+	$refund_beacon_sent = give_get_meta( $donation_id, '_give_ga_refund_beacon_sent', true );
+	if ( ! empty( $refund_beacon_sent ) ) {
+		return false;
+	}
+
 	// Bailout.
 	if ( 'refunded' === $new_status || 'publish' === $old_status ) {
-		// Check if the beacon has already been sent.
-		$beacon_sent = give_get_meta( $donation_id, '_give_ga_refund_beacon_sent', true );
-
-		if ( ! empty( $beacon_sent ) ) {
-			return false;
-		}
 
 		$ua_code   = give_get_option( 'google_analytics_ua_code' );
 		$client_id = give_get_meta( $donation_id, '_give_ga_client_id', true );
@@ -329,7 +337,6 @@ function give_google_analytics_donation_form() {
 				} else {
 					return '';
 				}
-				;
 			}
 
 		})(jQuery); //

--- a/includes/filters.php
+++ b/includes/filters.php
@@ -16,8 +16,15 @@ function give_google_analytics_refund_tracking( $do_change, $donation_id, $new_s
 		return $do_change;
 	}
 
-	// Check if refund tracking is enabled.
+	// Check if refund tracking is enabled. If not, return original change.
 	if ( ! give_is_setting_enabled( give_get_option( 'google_analytics_refunds_option' ) ) ) {
+		return $do_change;
+	}
+
+	// Only send refund if initial donation was sent to GA.
+	// For instance, a donation may have been added manually.
+	$beacon_sent = give_get_meta( $donation_id, '_give_ga_beacon_sent', true );
+	if ( empty( $beacon_sent ) ) {
 		return $do_change;
 	}
 
@@ -30,7 +37,7 @@ function give_google_analytics_refund_tracking( $do_change, $donation_id, $new_s
 	}
 
 	// Important to always return.
-	return $do_change;
+	return apply_filters( 'give_google_analytics_refund_tracking_beacon', $do_change, $donation_id );
 
 }
 

--- a/includes/give-google-analytics-functions.php
+++ b/includes/give-google-analytics-functions.php
@@ -11,6 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Helper function to check conditions for triggering GA tracking code.
  *
+ * @TODO: this function is not in use and is a near duplicate of give_ga_can_send_event() below. Either this should be removed or used.
+ *
  * @since 1.1
  *
  * @param $payment_id
@@ -19,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function give_should_send_beacon( $payment_id ) {
 
-	$sent_already = get_post_meta( $payment_id, '_give_ga_beacon_sent', true );
+	$sent_already = give_get_meta( $payment_id, '_give_ga_beacon_sent', true );
 
 	// Check meta beacon flag.
 	if ( ! empty( $sent_already ) ) {
@@ -28,6 +30,11 @@ function give_should_send_beacon( $payment_id ) {
 
 	// Don't track site admins.
 	if ( is_user_logged_in() && current_user_can( 'administrator' ) ) {
+		return false;
+	}
+
+	// Don't track manual donations.
+	if ( isset( $_GET['page'] ) && 'give-manual-donation' === $_GET['page'] ) {
 		return false;
 	}
 
@@ -97,7 +104,6 @@ function give_ga_has_tracking_id() {
 	return ! empty( $tracking_id );
 }
 
-
 /**
  * Check if plugin can send google vent or not.
  *
@@ -106,6 +112,12 @@ function give_ga_has_tracking_id() {
  * @return bool
  */
 function give_ga_can_send_event() {
+
+	// Don't track manual donations.
+	if ( isset( $_GET['page'] ) && 'give-manual-donation' === $_GET['page'] ) {
+		return false;
+	}
+
 	// Don't continue if test mode is enabled and test mode tracking is disabled.
 	if ( give_is_test_mode() && ! give_google_analytics_track_testing() ) {
 		return false;


### PR DESCRIPTION
## PR Overview

I reviewed the logic in the plugin for how donations and refunds are tracked and ensured that donations processed through Manual Donations are no longer being tracked.

I also reviewed some of the WP functions are replaced them with the Give Core equivalents.