### PR TITLE
fix: admin settings page is broken with Give 2.5.0 #42

### DIFF
--- a/includes/class-give-google-analytics-settings.php
+++ b/includes/class-give-google-analytics-settings.php
@@ -1,5 +1,17 @@
 <?php
+/**
+ * Give Google Analytics - Settings
+ *
+ * @package    Give
+ * @copyright  Copyright (c) 2019, GiveWP
+ * @license    https://opensource.org/licenses/gpl-license GNU Public License
+ * @since      1.2.4
+ */
 
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 /**
  * Class Give_Google_Analytics_Settings
  *
@@ -106,6 +118,10 @@ class Give_Google_Analytics_Settings {
 
 		$give_ga__settings = array(
 			array(
+				'id'   => 'give_title_google_analytics',
+				'type' => 'title',
+			),
+			array(
 				'name' => __( 'Google Analytics', 'give-google-analytics' ),
 				'desc' => '',
 				'id'   => 'give_google_analytics_title',
@@ -188,6 +204,10 @@ class Give_Google_Analytics_Settings {
 				'url'   => esc_url( 'http://docs.givewp.com/addon-google-analytics' ),
 				'title' => __( 'Google Analytics Add-on Documentation', 'give-google-analytics' ),
 				'type'  => 'give_docs_link',
+			),
+			array(
+				'id'   => 'give_title_google_analytics',
+				'type' => 'sectionend',
 			),
 		);
 

--- a/includes/class-give-google-analytics-settings.php
+++ b/includes/class-give-google-analytics-settings.php
@@ -64,8 +64,8 @@ class Give_Google_Analytics_Settings {
 		$this->section_label = __( 'Google Analytics', 'give-google-analytics' );
 
 		// Add settings.
-		add_filter( 'give_get_settings_general', array( $this, 'add_settings' ), 99999 );
-		add_filter( 'give_get_sections_general', array( $this, 'add_section' ), 99999 );
+		add_filter( 'give_get_settings_general', array( $this, 'add_settings' ) );
+		add_filter( 'give_get_sections_general', array( $this, 'add_section' ) );
 
 		add_filter( 'admin_enqueue_scripts', array( $this, 'add_scripts' ) );
 


### PR DESCRIPTION
## Description
This PR resolves #42 

## How Has This Been Tested?
I've tested this PR with `master` as well as `release/2.5.0` to ensure backward as well as forward compatibility.

## Screenshots (jpeg or gifs if applicable):
**master branch for Give core**
![image](https://user-images.githubusercontent.com/1852711/58705394-ad906800-83cc-11e9-9d4f-6e77599f838c.png)

**release/2.5.0 branch for Give core**
![image](https://user-images.githubusercontent.com/1852711/58705415-c6008280-83cc-11e9-92a8-661fc85029de.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.