### PR TITLE
make google analytic add-on compatible with Give 2.7.0 form template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/includes/actions.php
+++ b/includes/actions.php
@@ -363,3 +363,4 @@ function give_google_analytics_donation_form() {
 }
 
 add_action( 'wp_footer', 'give_google_analytics_donation_form', 99999 );
+add_action( 'give_embed_footer', 'give_google_analytics_donation_form', 99999 );


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This is related to: https://github.com/impress-org/givewp/pull/4659

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I tested this PR with the Sequoia form template (Give 2.7.0).

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/1784821/81593642-616fe500-93dd-11ea-949b-8e0cc1798e54.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
